### PR TITLE
Change the artifactId to express the project hosting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.jscookie</groupId>
+  <groupId>com.github.js-cookie</groupId>
   <artifactId>java-cookie</artifactId>
   <version>0.0.2-SNAPSHOT</version>
   <name>Java Cookie</name>


### PR DESCRIPTION
As specified by Thad Watson [here](https://issues.sonatype.org/browse/OSSRH-16716?focusedCommentId=323042&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-323042):

> Do you own the domain jscookie.org? If not, please read:
> http://central.sonatype.org/pages/choosing-your-coordinates.html
> You may also choose a groupId that reflects your project hosting, in this case, something like com.github.js-cookie
