### PR TITLE
Build fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "java-cookie",
   "devDependencies": {
-    "js-cookie": "master"
+    "js-cookie": "2.0.3"
   }
 }


### PR DESCRIPTION
js-cookie removed unnecessary files from bower.json that this project relied upon starting from version 2.0.4, see https://github.com/js-cookie/js-cookie/pull/83
