### PR TITLE
 Fix #17: JSON generates cookie that it cannot read

### DIFF
--- a/src/main/java/com/github/jscookie/javacookie/Cookies.java
+++ b/src/main/java/com/github/jscookie/javacookie/Cookies.java
@@ -296,17 +296,16 @@ public final class Cookies implements CookiesDefinition {
 				String character = new String( Character.toChars( codePoint ) );
 				CharArrayWriter hexSequence = new CharArrayWriter();
 				byte[] bytes = character.getBytes( UTF_8 );
-				for ( int bytesIndex = 0; bytesIndex < bytes.length; bytesIndex++ ) {
-					char left = Character.forDigit( bytes[ bytesIndex ] >> 4 & 0xF, 16 );
-					char right = Character.forDigit( bytes[ bytesIndex ] & 0xF, 16 );
+				for (byte aByte : bytes) {
+					char left = Character.forDigit(aByte >> 4 & 0xF, 16);
+					char right = Character.forDigit(aByte & 0xF, 16);
 					hexSequence
-						.append( '%' )
-						.append( left )
-						.append( right );
+							.append('%')
+							.append(left)
+							.append(right);
 				}
-				String target = character.toString();
 				String sequence = hexSequence.toString().toUpperCase();
-				encoded = encoded.replace( target, sequence );
+				encoded = encoded.replace(character, sequence );
 			} catch ( UnsupportedEncodingException e ) {
 				e.printStackTrace();
 			}
@@ -314,9 +313,14 @@ public final class Cookies implements CookiesDefinition {
 		return encoded;
 	}
 
-	private String decode( String encoded ) {
+	private String decode(String encoded) {
+		// Decode characters with 3 bytes first, then with 1 byte to fix https://github.com/js-cookie/java-cookie/issues/14
+		return decode( decode( encoded, 3 ), 1 );
+	}
+
+	private String decode( String encoded, Integer bytesPerCharacter ) {
 		String decoded = encoded;
-		Pattern pattern = Pattern.compile( "(%[0-9A-Z]{2})+" );
+		Pattern pattern = Pattern.compile( "(%[0-9A-Z]{2}){" + bytesPerCharacter + "}" );
 		Matcher matcher = pattern.matcher( encoded );
 		while ( matcher.find() ) {
 			String encodedChar = matcher.group();
@@ -392,14 +396,13 @@ public final class Cookies implements CookiesDefinition {
 	private Map<String, String> getCookies( String cookieHeader ) {
 		Map<String, String> result = new HashMap<String, String>();
 		String[] cookies = cookieHeader.split( "; " );
-		for ( int i = 0; i < cookies.length; i++ ) {
-			String cookie = cookies[ i ];
-			String encodedName = cookie.split( "=" )[ 0 ];
-			String decodedName = decode( encodedName );
+		for (String cookie : cookies) {
+			String encodedName = cookie.split("=")[0];
+			String decodedName = decode(encodedName);
 
-			String encodedValue = cookie.substring( cookie.indexOf( '=' ) + 1, cookie.length() );
-			String decodedValue = decodeValue( encodedValue, decodedName );
-			result.put( decodedName, decodedValue );
+			String encodedValue = cookie.substring(cookie.indexOf('=') + 1);
+			String decodedValue = decodeValue(encodedValue, decodedName);
+			result.put(decodedName, decodedValue);
 		}
 		return result;
 	}

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/CookiesWriteReadIT.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/CookiesWriteReadIT.java
@@ -76,7 +76,7 @@ public class CookiesWriteReadIT {
 
     // Read cookie
     driver.navigate().to(baseURL + "read_json?name=c");
-    Assert.assertEquals("{\"name\":\"c\",\"value\":\"v\"}", driver.findElement(By.id("json")).getText());
+    Assert.assertEquals("{\"attr1\":\"v\",\"attr2\":\"v\"}", driver.findElement(By.id("json")).getText());
 
     if (debug.is(false)) {
       driver.quit();

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/CookiesWriteReadIT.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/CookiesWriteReadIT.java
@@ -1,0 +1,86 @@
+package com.github.jscookie.javacookie.test.integration;
+
+import com.github.jscookie.javacookie.test.integration.test.utils.Debug;
+import com.github.jscookie.javacookie.test.unit.utils.IntegrationUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(Arquillian.class)
+public class CookiesWriteReadIT {
+  private static Debug debug = Debug.FALSE;
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    WebArchive war = IntegrationUtils.createCommonDeployment()
+      .addAsWebInfResource(
+        new File("src/test/resources/web.xml"),
+        "web.xml"
+      );
+
+    System.out.println(" ----- LOGGING THE FILES ADDED TO JBOSS");
+    System.out.println(war.toString(true));
+    System.out.println(" ----- END OF LOGGING THE FILES ADDED TO JBOSS");
+
+    return war;
+  }
+
+  @RunAsClient
+  @Test
+  public void write_read(@ArquillianResource URL baseURL) {
+    WebDriver driver = new FirefoxDriver();
+    driver.manage().timeouts().implicitlyWait(20, TimeUnit.SECONDS);
+
+    // Set simple cookie
+    driver.navigate().to(baseURL + "write?name=c&value=v");
+    Set<Cookie> cookies = driver.manage().getCookies();
+    Assert.assertEquals(1, cookies.size());
+    Assert.assertEquals("c", cookies.iterator().next().getName());
+    Assert.assertEquals("v", cookies.iterator().next().getValue());
+
+    // Read cookie
+    driver.navigate().to(baseURL + "read?name=c");
+    Assert.assertEquals("{\"name\":\"c\",\"value\":\"v\"}", driver.findElement(By.id("json")).getText());
+
+    if (debug.is(false)) {
+      driver.quit();
+    }
+  }
+
+  @RunAsClient
+  @Test
+  public void write_read_json(@ArquillianResource URL baseURL) {
+    WebDriver driver = new FirefoxDriver();
+    driver.manage().timeouts().implicitlyWait(20, TimeUnit.SECONDS);
+
+    // Set JSON cookie
+    driver.navigate().to(baseURL + "write_json?name=c&value=v");
+    Set<Cookie> cookies = driver.manage().getCookies();
+    Assert.assertEquals(1, cookies.size());
+    Assert.assertEquals("c", cookies.iterator().next().getName());
+    Assert.assertEquals("{%22attr1%22:%22v%22%2C%22attr2%22:%22v%22}", cookies.iterator().next().getValue());
+
+    // Read cookie
+    driver.navigate().to(baseURL + "read_json?name=c");
+    Assert.assertEquals("{\"name\":\"c\",\"value\":\"v\"}", driver.findElement(By.id("json")).getText());
+
+    if (debug.is(false)) {
+      driver.quit();
+    }
+  }
+
+}

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/ReadCookieServlet.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/ReadCookieServlet.java
@@ -1,0 +1,27 @@
+package com.github.jscookie.javacookie.test.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.jscookie.javacookie.Cookies;
+import com.github.jscookie.javacookie.test.integration.test.utils.IntegrationTestUtils;
+import com.github.jscookie.javacookie.test.integration.test.utils.Result;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ReadCookieServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Cookies cookies = Cookies.initFromServlet(request, response);
+
+    String name = IntegrationTestUtils.getUTF8Param("name", request);
+    String value = cookies.get(name);
+
+    response.setContentType("application/json");
+    new ObjectMapper()
+      .writeValue(response.getOutputStream(), new Result(name, value));
+  }
+
+}

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/ReadJSONCookieServlet.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/ReadJSONCookieServlet.java
@@ -1,0 +1,34 @@
+package com.github.jscookie.javacookie.test.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.jscookie.javacookie.CookieParseException;
+import com.github.jscookie.javacookie.Cookies;
+import com.github.jscookie.javacookie.test.integration.test.utils.CustomJSONCookie;
+import com.github.jscookie.javacookie.test.integration.test.utils.IntegrationTestUtils;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ReadJSONCookieServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Cookies cookies = Cookies.initFromServlet(request, response);
+
+    String name = IntegrationTestUtils.getUTF8Param("name", request);
+
+    CustomJSONCookie customJSONCookie;
+    try {
+      customJSONCookie = cookies.get(name, CustomJSONCookie.class);
+      if (customJSONCookie != null) {
+        response.setContentType("application/json");
+        new ObjectMapper().writeValue(response.getOutputStream(), customJSONCookie);
+      }
+    } catch (CookieParseException e) {
+      e.printStackTrace();
+    }
+
+  }
+}

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/WriteCookieServlet.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/WriteCookieServlet.java
@@ -1,0 +1,29 @@
+package com.github.jscookie.javacookie.test.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.jscookie.javacookie.Cookies;
+import com.github.jscookie.javacookie.test.integration.test.utils.IntegrationTestUtils;
+import com.github.jscookie.javacookie.test.integration.test.utils.Result;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class WriteCookieServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Cookies cookies = Cookies.initFromServlet(request, response);
+
+    String name = IntegrationTestUtils.getUTF8Param("name", request);
+    String value = IntegrationTestUtils.getUTF8Param("value", request);
+
+    cookies.set(name, value);
+
+    response.setContentType("application/json");
+    new ObjectMapper()
+      .writeValue(response.getOutputStream(), new Result(name, value));
+  }
+
+}

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/WriteJSONCookieServlet.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/WriteJSONCookieServlet.java
@@ -1,0 +1,35 @@
+package com.github.jscookie.javacookie.test.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.jscookie.javacookie.CookieSerializationException;
+import com.github.jscookie.javacookie.Cookies;
+import com.github.jscookie.javacookie.test.integration.test.utils.CustomJSONCookie;
+import com.github.jscookie.javacookie.test.integration.test.utils.IntegrationTestUtils;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class WriteJSONCookieServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Cookies cookies = Cookies.initFromServlet(request, response);
+
+    String name = IntegrationTestUtils.getUTF8Param("name", request);
+    String value = IntegrationTestUtils.getUTF8Param("value", request);
+
+    CustomJSONCookie customJSONCookie = new CustomJSONCookie(value, value);
+
+    try {
+      cookies.set(name, customJSONCookie);
+    } catch (CookieSerializationException e) {
+      e.printStackTrace();
+    }
+
+    response.setContentType("application/json");
+    new ObjectMapper()
+        .writeValue(response.getOutputStream(), customJSONCookie);
+  }
+}

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/encoding/EncodingServlet.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/encoding/EncodingServlet.java
@@ -11,13 +11,15 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jscookie.javacookie.Cookies;
+import com.github.jscookie.javacookie.test.integration.test.utils.IntegrationTestUtils;
+import com.github.jscookie.javacookie.test.integration.test.utils.Result;
 
 public class EncodingServlet extends HttpServlet {
 	private static final long serialVersionUID = 1;
 	@Override
 	public void doGet( HttpServletRequest request, HttpServletResponse response )
 	throws ServletException, IOException {
-		String name = getUTF8Param( "name", request );
+		String name = IntegrationTestUtils.getUTF8Param( "name", request );
 
 		System.out.println( "Testing: " + name );
 
@@ -35,31 +37,4 @@ public class EncodingServlet extends HttpServlet {
 			.writeValue( response.getOutputStream(), new Result( name, value ) );
 	}
 
-	/**
-	 * Retrieves the parameter using UTF-8 charset since the server default is ISO-8859-1
-	 */
-	private String getUTF8Param( String name, HttpServletRequest request ) throws UnsupportedEncodingException {
-		String query = request.getQueryString();
-		for ( String pair : query.split( "&" ) ) {
-			if ( name.equals( pair.split( "=" )[ 0 ] ) ) {
-				return URLDecoder.decode( pair.split( "=" )[ 1 ], "UTF-8" );
-			}
-		}
-		return null;
-	}
-}
-
-class Result {
-	private String name;
-	private String value;
-	Result( String name, String value ) {
-		this.name = name;
-		this.value = value;
-	}
-	public String getName() {
-		return name;
-	}
-	public String getValue() {
-		return value;
-	}
 }

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/test/utils/CustomJSONCookie.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/test/utils/CustomJSONCookie.java
@@ -1,0 +1,21 @@
+package com.github.jscookie.javacookie.test.integration.test.utils;
+
+import com.github.jscookie.javacookie.CookieValue;
+
+public class CustomJSONCookie implements CookieValue {
+  private String attr1;
+  private String attr2;
+
+  public CustomJSONCookie(String attr1, String attr2) {
+    this.attr1 = attr1;
+    this.attr2 = attr2;
+  }
+
+  public String getAttr1() {
+    return attr1;
+  }
+
+  public String getAttr2() {
+    return attr2;
+  }
+}

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/test/utils/CustomJSONCookie.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/test/utils/CustomJSONCookie.java
@@ -1,12 +1,15 @@
 package com.github.jscookie.javacookie.test.integration.test.utils;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jscookie.javacookie.CookieValue;
 
 public class CustomJSONCookie implements CookieValue {
   private String attr1;
   private String attr2;
 
-  public CustomJSONCookie(String attr1, String attr2) {
+  @JsonCreator
+  public CustomJSONCookie(@JsonProperty("attr1") String attr1, @JsonProperty("attr2") String attr2) {
     this.attr1 = attr1;
     this.attr2 = attr2;
   }

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/test/utils/IntegrationTestUtils.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/test/utils/IntegrationTestUtils.java
@@ -1,0 +1,20 @@
+package com.github.jscookie.javacookie.test.integration.test.utils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+public class IntegrationTestUtils {
+  /**
+   * Retrieves the parameter using UTF-8 charset since the server default is ISO-8859-1
+   */
+  public static String getUTF8Param( String name, HttpServletRequest request ) throws UnsupportedEncodingException {
+    String query = request.getQueryString();
+    for ( String pair : query.split( "&" ) ) {
+      if ( name.equals( pair.split( "=" )[ 0 ] ) ) {
+        return URLDecoder.decode( pair.split( "=" )[ 1 ], "UTF-8" );
+      }
+    }
+    return null;
+  }
+}

--- a/src/test/java/com/github/jscookie/javacookie/test/integration/test/utils/Result.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/integration/test/utils/Result.java
@@ -1,0 +1,16 @@
+package com.github.jscookie.javacookie.test.integration.test.utils;
+
+public class Result {
+  private String name;
+  private String value;
+  public Result( String name, String value ) {
+    this.name = name;
+    this.value = value;
+  }
+  public String getName() {
+    return name;
+  }
+  public String getValue() {
+    return value;
+  }
+}

--- a/src/test/java/com/github/jscookie/javacookie/test/unit/CookiesDecodingTest.java
+++ b/src/test/java/com/github/jscookie/javacookie/test/unit/CookiesDecodingTest.java
@@ -34,4 +34,12 @@ public class CookiesDecodingTest extends BaseTest {
 		String expected = "京";
 		Assert.assertEquals( expected, actual );
 	}
+
+	@Test
+	public void two_encoded_characters() {
+		Mockito.when(request.getHeader("cookie")).thenReturn("c=New%20York%2C%20NY");
+		String actual = cookies.get("c");
+		String expected = "New York, NY";
+		Assert.assertEquals(expected, actual);
+	}
 }

--- a/src/test/resources/web.xml
+++ b/src/test/resources/web.xml
@@ -6,8 +6,40 @@
     <servlet-name>encoding</servlet-name>
     <servlet-class>com.github.jscookie.javacookie.test.integration.encoding.EncodingServlet</servlet-class>
   </servlet>
+  <servlet>
+    <servlet-name>write</servlet-name>
+    <servlet-class>com.github.jscookie.javacookie.test.integration.WriteCookieServlet</servlet-class>
+  </servlet>
+  <servlet>
+    <servlet-name>read</servlet-name>
+    <servlet-class>com.github.jscookie.javacookie.test.integration.ReadCookieServlet</servlet-class>
+  </servlet>
+  <servlet>
+    <servlet-name>write_json</servlet-name>
+    <servlet-class>com.github.jscookie.javacookie.test.integration.WriteJSONCookieServlet</servlet-class>
+  </servlet>
+  <servlet>
+    <servlet-name>read_json</servlet-name>
+    <servlet-class>com.github.jscookie.javacookie.test.integration.ReadJSONCookieServlet</servlet-class>
+  </servlet>
   <servlet-mapping>
     <servlet-name>encoding</servlet-name>
     <url-pattern>/encoding</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>write</servlet-name>
+    <url-pattern>/write</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>read</servlet-name>
+    <url-pattern>/read</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>write_json</servlet-name>
+    <url-pattern>/write_json</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>read_json</servlet-name>
+    <url-pattern>/read_json</url-pattern>
   </servlet-mapping>
 </web-app>


### PR DESCRIPTION
- Integration test for setting and reading simple/JSON cookies
- Fix test by merging the fix for #14
- Fix needs to be verified with `mvn verify`, as integration tests are not running in Travis
- Merge #21 first, it should not conflict.